### PR TITLE
Updated Enpass to V5.6.5

### DIFF
--- a/automatic/enpass.install/enpass.install.nuspec
+++ b/automatic/enpass.install/enpass.install.nuspec
@@ -5,9 +5,9 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>enpass.install</id>
     <title>Enpass Password Manager</title>
-    <version>5.6.0</version>
+    <version>5.6.5</version>
     <authors>Sinew Software Systems</authors>
-    <owners>alazare619 w0ndersp00n</owners>
+    <owners>alazare619 w0ndersp00n royvou</owners>
     <summary>Enpass</summary>
     <description>Enpass takes care of all your life important credentials and online accounts in best way. All your data is secured offline on your device only, not on our servers. Enpass encrypts your data by AES 256 bit Encryption using open-source encryption engine SQLCipher to ensure maximum security with trust.</description>
     <projectUrl>https://www.enpass.io/downloads/</projectUrl>

--- a/automatic/enpass.install/tools/chocolateyInstall.ps1
+++ b/automatic/enpass.install/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $packageName = 'Enpass'
-$url         = 'https://dl.sinew.in/windows/setup/5-6-0-0/Enpass_5.6.0_Setup.exe'
-$checksum    = '937b3ea2331bc96289fbf6ec9c3a2259c1c6e44657ec57a1e70d0248da27d8c2'
+$url         = 'https://dl.sinew.in/windows/setup/5-6-5-1/Enpass_5.6.5_Setup.exe'
+$checksum    = '5D85DA4551A830F0146D106D73E37514D5FD67F2EE599A696AC75BD9F8904646'
 
 $packageArgs = @{
   packageName            = $packageName


### PR DESCRIPTION
This PR will update the enpass.install version from V5.6.0 to V5.6.5

I haven't used the auto-update script since the download url will become incorrect.